### PR TITLE
Explicitly declaring the event in EventHandler as KeyboardEvent. 

### DIFF
--- a/flappyengine/src/GameEngine/EventHandler/EventHandler.ts
+++ b/flappyengine/src/GameEngine/EventHandler/EventHandler.ts
@@ -4,12 +4,14 @@
  */
 
 export class EventHandler{
-
-    
+    /*
+    The event types "keydown" and "keyup" implies keyboard events only
+    A future development will be handling other events, like mouse clicks.
+     */
 
     keyPressDown(keycode : string, method: any) {
 
-        window.addEventListener("keydown", event => {
+        window.addEventListener("keydown", (event: KeyboardEvent) => {
             event.preventDefault();
 
             if (event.isComposing || event.code === keycode) {
@@ -20,7 +22,7 @@ export class EventHandler{
 
     keyPressUp(keycode : string, method: any) {
 
-        window.addEventListener("keyup", event => {
+        window.addEventListener("keyup", (event:KeyboardEvent) => {
             event.preventDefault();
 
             if (event.isComposing || event.code === keycode) {


### PR DESCRIPTION
Much easier to read, and making clear that other events are not handled here. Lack of declaration made me try to test it with a more general Event event.