### PR TITLE
Dodge works with empty Game tag and no warning

### DIFF
--- a/flappyengine/src/App.js
+++ b/flappyengine/src/App.js
@@ -3,7 +3,7 @@ import './App.css';
 import Game from './Dodge/game/components/Dodge'
 
 function App() {
-  return ( <Game></Game> );
+  return ( <Game/> );
 }
 
 export default App;


### PR DESCRIPTION
No change in functionality, but always good to get rid of a meaningless warning